### PR TITLE
fix missing cstdio headers in old versions of SAD

### DIFF
--- a/source/3.08/shared.h
+++ b/source/3.08/shared.h
@@ -8,6 +8,8 @@
 
 #define _XSHARX_H 1
 
+#include  <stdio.h>
+
 typedef unsigned char  uchar;
 typedef unsigned short ushort;
 typedef unsigned int   uint;

--- a/source/4.0.3/shared.h
+++ b/source/4.0.3/shared.h
@@ -18,6 +18,8 @@
 
 #define _XSHARX_H 1
 
+#include  <stdio.h>
+
 typedef unsigned char  uchar;
 typedef unsigned short ushort;
 typedef unsigned int   uint;

--- a/source/4.0.4/shared.h
+++ b/source/4.0.4/shared.h
@@ -18,6 +18,8 @@
 
 #define _XSHARX_H 1
 
+#include  <stdio.h>
+
 typedef unsigned char  uchar;
 typedef unsigned short ushort;
 typedef unsigned int   uint;

--- a/source/4.0.5/shared.h
+++ b/source/4.0.5/shared.h
@@ -18,6 +18,8 @@
 
 #define _XSHARX_H 1
 
+#include  <stdio.h>
+
 typedef unsigned char  uchar;
 typedef unsigned short ushort;
 typedef unsigned int   uint;


### PR DESCRIPTION
I've had this around for a while. it just adds `#include  <stdio.h>` to shared.h for old versions of SAD. it is no longer required with 4.0.6, as it's been fixed. This just fixes building from a makefile with old versions. There's some weird automatic whitespace changes caused by mismatched line endings, so you don't have to pull this as is. Just add the include to SAD 3.08, 4.0.3, 4.0.4, 4.0.5.